### PR TITLE
Debug Makefile.in, it should fix #8

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -29,7 +29,7 @@ mpsse.o: support.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -DLIBFTDI1=$(LIBFTDI1) -c mpsse.c
 
 fast.o: support.o
-	$(CC) $(CFLAGS) $(LDFLAGS) -c fast.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -DLIBFTDI1=$(LIBFTDI1) -c fast.c
 
 support.o:
 	$(CC) $(CFLAGS) $(LDFLAGS) -DLIBFTDI1=$(LIBFTDI1) -c support.c


### PR DESCRIPTION
As fast.c include maps.h, it need LIBFTDI1 define (compilation error on OS X without that).