### PR TITLE
Update mpsse.i

### DIFF
--- a/src/mpsse.i
+++ b/src/mpsse.i
@@ -1,4 +1,5 @@
 %module pylibmpsse
+%include "stdint.i"
 %{
 #include "mpsse.h"
 %}


### PR DESCRIPTION
I found that calling the SetDirection function from python led to a TypeError due to the uint8_t parameter in the function declaration

```C
int SetDirection(struct mpsse_context *mpsse, uint8_t direction);
```
Stack exchange said I could just include stdint.i in the mpsse.i file.  I recompiled and confirmed that the error disappeared.

https://stackoverflow.com/questions/8897294/swig-python-c-how-to-use-type-int8-t