### PR TITLE
Minor code cleanup for malloc() and C++.

### DIFF
--- a/src/mpsse.h
+++ b/src/mpsse.h
@@ -39,6 +39,10 @@
 
 #define NULL_CONTEXT_ERROR_MSG	"NULL MPSSE context pointer!"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* FTDI interfaces */
 enum interface
 {
@@ -224,5 +228,8 @@ int FastRead(struct mpsse_context *mpsse, char *data, int size);
 int FastTransfer(struct mpsse_context *mpsse, char *wdata, char *rdata, int size);
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/support.c
+++ b/src/support.c
@@ -5,6 +5,7 @@
  * 27 December 2011
  */
 
+#include <stdlib.h>
 #include <string.h>
 
 #if LIBFTDI1 == 1


### PR DESCRIPTION
- Include <stdlib.h> in support.c to ensure that malloc() is properly
  declared.
- Wrap type and function declarations in mpsse.h with an "extern C"
  block so that symbol names aren't mangled when used from C++.
