### PR TITLE
Fix compilation error caused by missing libftdi define

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -6,8 +6,7 @@ SONAME=@SONAME@
 FRAMEWORK=@FRAMEWORK@
 BUILD=@BUILD@
 LDFLAGS=@LDFLAGS@
-CFLAGS=@CFLAGS@
-LIBFTDI1=@LIBFTDI1@
+CFLAGS=@CFLAGS@ -DLIBFTDI1=@LIBFTDI1@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 LIBDIR=@libdir@
@@ -26,19 +25,19 @@ example-code:
 	make -C examples
 
 mpsse.o: support.o
-	$(CC) $(CFLAGS) $(LDFLAGS) -DLIBFTDI1=$(LIBFTDI1) -c mpsse.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -c mpsse.c
 
 fast.o: support.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -c fast.c
 
 support.o:
-	$(CC) $(CFLAGS) $(LDFLAGS) -DLIBFTDI1=$(LIBFTDI1) -c support.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -c support.c
 
 pyswig-build:
-	$(CC) $(CFLAGS) $(LDFLAGS) -DSWIGPYTHON -DLIBFTDI1=$(LIBFTDI1) -c support.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -DSWIGPYTHON -DLIBFTDI1=$(LIBFTDI1) -c mpsse.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -DSWIGPYTHON -c support.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -DSWIGPYTHON -c mpsse.c
 	$(SWIG) -python $(TARGET).i
-	$(CC) $(CFLAGS) -c  -DLIBFTDI1=$(LIBFTDI1) $(TARGET)_wrap.c  $(INC)
+	$(CC) $(CFLAGS) -c $(TARGET)_wrap.c  $(INC)
 	$(CC) $(CFLAGS) -shared $(FRAMEWORK) $(TARGET)_wrap.o mpsse.o support.o \
 		-o _pylib$(TARGET).so $(LDFLAGS) $(INC)
 


### PR DESCRIPTION
Hi,

I have compilation problem in OpenEmbedded build system. Here is a simple commit fixing the issue. I hope that it won't break compilation with different ftdi library.

More information are in the commit message.

Hmm, I just saw that fix for tha same problem is in #9 .

Tomas