### PR TITLE
Don't use install -D option as it does not exist on OS X

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -43,9 +43,10 @@ pyswig-build:
 		-o _pylib$(TARGET).so $(LDFLAGS) $(INC)
 
 pyswig-install:
-	install -D -m644 pylib$(TARGET).py  $(DESTDIR)/$(PYLIB)/pylib$(TARGET).py
-	install -D -m644 _pylib$(TARGET).so $(DESTDIR)/$(PYLIB)/_pylib$(TARGET).so
-	install -D -m644 $(TARGET).py       $(DESTDIR)/$(PYLIB)/$(TARGET).py
+	install -d -m755 $(DESTDIR)/$(PYLIB)
+	install -m644 pylib$(TARGET).py  $(DESTDIR)/$(PYLIB)/pylib$(TARGET).py
+	install -m644 _pylib$(TARGET).so $(DESTDIR)/$(PYLIB)/_pylib$(TARGET).so
+	install -m644 $(TARGET).py       $(DESTDIR)/$(PYLIB)/$(TARGET).py
 
 pyswig-uninstall:
 	rm -f $(DESTDIR)/$(PYLIB)/$(TARGET).* \
@@ -58,9 +59,11 @@ py-install:
 py-uninstall:
 
 install: py$(BUILD)-install
-	install -D -m644 lib$(TARGET).so $(DESTDIR)/$(LIBDIR)/lib$(TARGET).so
-	install -D -m644 lib$(TARGET).a  $(DESTDIR)/$(LIBDIR)/lib$(TARGET).a
-	install -D -m644 $(TARGET).h     $(DESTDIR)/$(INCDIR)/$(TARGET).h
+	install -d -m755 $(DESTDIR)/$(LIBDIR) $(DESTDIR)/$(INCDIR)
+	install -m644 $(TARGET).h     $(DESTDIR)/$(INCDIR)/$(TARGET).h
+	install -m644 lib$(TARGET).so $(DESTDIR)/$(LIBDIR)/lib$(TARGET).so
+	install -m644 lib$(TARGET).a  $(DESTDIR)/$(LIBDIR)/lib$(TARGET).a
+	install -m644 $(TARGET).h     $(DESTDIR)/$(INCDIR)/$(TARGET).h
 
 uninstall: py$(BUILD)-uninstall
 	rm -f $(DESTDIR)/$(LIBDIR)/lib$(TARGET).so \


### PR DESCRIPTION
Since the -D option does not exist in the OS X install tool, the install fails. The fix first creates the directory with the -d option and then uses install without the -D.