### PR TITLE
Enabling distribution via. pypi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+
+python-wheel:
+	docker run -it -v $(PWD):/io quay.io/pypa/manylinux1_x86_64 /io/build_wheels.sh
+
+clean:
+	sudo rm -rf wheelhouse

--- a/build_wheels.sh
+++ b/build_wheels.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+yum install -y swig libftdi-devel
+
+/opt/python/cp27-cp27mu/bin/pip wheel /io/ -w /io/wheelhouse/
+
+auditwheel repair /io/wheelhouse/libmpsse*.whl -w /io/wheelhouse/

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import re
+from setuptools import setup
+from setuptools.extension import Extension
+
+with open('src/configure', 'r') as fd:
+    version = re.search(
+        r'PACKAGE_VERSION=\'(.+)\'',
+        fd.read(),
+        re.MULTILINE).group(1)
+
+with open('docs/README', 'r') as fd:
+    readme = fd.read()
+
+setup(
+    name='libmpsse',
+    version=version,
+    description='Library to interface with SPI/I2C via. FTDI',
+    log_description=readme,
+    author='devttys0',
+    url='https://github.com/devttys0/libmpsse/tree/master/docs',
+    classifiers=(
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+    ),
+    package_dir={
+        '': 'src'
+    },
+    py_modules=[
+        "mpsse",
+        "pylibmpsse"
+    ],
+    ext_modules=[
+        Extension(
+            '_pylibmpsse',
+            [
+                'src/mpsse.c',
+                'src/mpsse.i',
+                'src/support.c',
+                'src/fast.c'
+            ],
+            libraries=['ftdi']
+        )
+    ],
+)


### PR DESCRIPTION
We needed an easier way to use this as a dependency. `python setup.py build` now works.