### PR TITLE
Extern fast_rw_buf properly.

### DIFF
--- a/src/fast.c
+++ b/src/fast.c
@@ -10,6 +10,9 @@
 #include "mpsse.h"
 #include "support.h"
 
+unsigned char fast_rw_buf[SPI_RW_SIZE + CMD_SIZE];
+
+
 /* Builds a block buffer for the Fast* functions. For internal use only. */
 int fast_build_block_buffer(struct mpsse_context *mpsse, uint8_t cmd, unsigned char *data, int size, int *buf_size)
 {

--- a/src/mpsse.h
+++ b/src/mpsse.h
@@ -218,7 +218,7 @@ swig_string_data Transfer(struct mpsse_context *mpsse, char *data, int size);
 char *Read(struct mpsse_context *mpsse, int size);
 char *Transfer(struct mpsse_context *mpsse, char *data, int size);
 
-unsigned char fast_rw_buf[SPI_RW_SIZE + CMD_SIZE];
+extern unsigned char fast_rw_buf[SPI_RW_SIZE + CMD_SIZE];
 int FastWrite(struct mpsse_context *mpsse, char *data, int size);
 int FastRead(struct mpsse_context *mpsse, char *data, int size);
 int FastTransfer(struct mpsse_context *mpsse, char *wdata, char *rdata, int size);


### PR DESCRIPTION
Original code will cause  "multiple definition of `fast_rw_buf'" problems as this variable wasn't extern'ed properly. Compilers are getting less forgiving, so this fix is required to compile with a modern GCC with it's current defaults.